### PR TITLE
Create CDEProjectBrowserItem only if Application folder matches for storePath and modelPath

### DIFF
--- a/Core Data Editor/Core Data Editor/CDEProjectBrowserWindowController.m
+++ b/Core Data Editor/Core Data Editor/CDEProjectBrowserWindowController.m
@@ -145,8 +145,13 @@
             [metadataByStorePath enumerateKeysAndObjectsUsingBlock:^(NSString *storePath, NSDictionary *metadata, BOOL *stop) {
                 BOOL isCompatible = [model isConfiguration:nil compatibleWithStoreMetadata:metadata];
                 if(isCompatible) {
-                    CDEProjectBrowserItem *item = [[CDEProjectBrowserItem alloc] initWithStorePath:storePath modelPath:modelPath];
-                    [items addObject:item];
+                    NSString *storePathAppName = [[NSURL fileURLWithPath:storePath] appFolderName_cde];
+                    NSString *modelPathAppName = [[NSURL fileURLWithPath:modelPath] appFolderName_cde];
+                    BOOL sameApplication = [storePathAppName isEqualToString:modelPathAppName];
+                    if (sameApplication) {
+                        CDEProjectBrowserItem *item = [[CDEProjectBrowserItem alloc] initWithStorePath:storePath modelPath:modelPath];
+                        [items addObject:item];
+                    }
                 }
             }];
         }];

--- a/Core Data Editor/Core Data Editor/NSURL+CDEAdditions.h
+++ b/Core Data Editor/Core Data Editor/NSURL+CDEAdditions.h
@@ -8,6 +8,15 @@
 
 #pragma mark - UTI
 - (NSString *)typeOfFileURLAndGetError_cde:(NSError **)error;
+/**
+ * Return the Application name if the NSURL contains it. nil if not found
+ * Example:
+ *  Input:  /iPhone Simulator/7.1/Applications/412F2A6B-0F54-4F98-AE1B-DFE99E057DB1/Example.app/v1.momd/v5.mom
+ *  Output: 412F2A6B-0F54-4F98-AE1B-DFE99E057DB1
+ *
+ * @return NSString*
+ */
+- (NSString *)appFolderName_cde;
 - (BOOL)isCompiledManagedObjectModelFile_cde;
 
 #pragma mark - App Specific URLs

--- a/Core Data Editor/Core Data Editor/NSURL+CDEAdditions.m
+++ b/Core Data Editor/Core Data Editor/NSURL+CDEAdditions.m
@@ -35,6 +35,26 @@
     return [workspace typeOfFile:self.path error:error];
 }
 
+- (NSString *)appFolderName_cde {
+    // Retrieve the "Applications" folder name (usually "Applications")
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationDirectory, NSLocalDomainMask, YES);
+    if (paths.count == 0) {
+        return nil;
+    }
+    NSString *applicationsFolderName = [[paths objectAtIndex:0] lastPathComponent];
+    // Loop through the pathComponents, searching for the "Applications" folder, the next component will contain the app folder
+    // Applications/412F2A6B-0F54-4F98-AE1B-DFE99E057DB1
+    for (NSInteger index = 0; index < self.pathComponents.count; index++) {
+        NSString *component = [self.pathComponents objectAtIndex:index];
+        NSInteger nextIndex = index + 1;
+        if ([component isEqualToString:applicationsFolderName]
+            && nextIndex < self.pathComponents.count) {
+            return [self.pathComponents objectAtIndex:nextIndex];
+        }
+    }
+    return nil;
+}
+
 - (BOOL)isCompiledManagedObjectModelFile_cde {
     NSError *error = nil;
     NSWorkspace *workspace = [NSWorkspace sharedWorkspace];


### PR DESCRIPTION
I noticed that when I opened the "Project Browser", some applications were duplicated.

While debugging the code that retrieves the apps list, I noticed how it duplicates `storePath` and `modelPath` when you installed your app in more than 1 simulator.

MyApp is installed on iOS 7.1 and iOS 6.1 simulators, and it produces the following array `CDEProjectBrowserItem *`

CDEProjectBrowserItem1
.../7.1Applications/412F2A6B-0F54-4F98-AE1B-DFE99E057DB1/Documents/MyStoreFile.sqlite,
.../7.1/Applications/412F2A6B-0F54-4F98-AE1B-DFE99E057DB1/MyApp.app/v1.momd/v1.mom,

CDEProjectBrowserItem2
.../6.1Applications/F3B606E7-8CC1-48E9-944D-079CE1F77173/Documents/MyStoreFile.sqlite,
.../7.1/Applications/412F2A6B-0F54-4F98-AE1B-DFE99E057DB1/MyApp.app/v1.momd/v1.mom,

CDEProjectBrowserItem3
.../7.1Applications/412F2A6B-0F54-4F98-AE1B-DFE99E057DB1/Documents/MyStoreFile.sqlite,
.../6.1/Applications/F3B606E7-8CC1-48E9-944D-079CE1F77173/MyApp.app/v1.momd/v1.mom,

CDEProjectBrowserItem4
.../6.1Applications/F3B606E7-8CC1-48E9-944D-079CE1F77173/Documents/MyStoreFile.sqlite,
.../6.1/Applications/F3B606E7-8CC1-48E9-944D-079CE1F77173/MyApp.app/v1.momd/v1.mom,

Note how we don't want to have CDEProjectBrowserItem2 and CDEProjectBrowserItem3 (i.e mixing apps with different app folder in different simulators)
I applied a fix, playing with a NSURL category in order to retrieve the app folder name, making sure that the `storePath` app name matches the `modelPath` app name.
There is an assumption that the app folder name is in the path component after "Applications", and that 2 simulators haven't an app with the same folder name (UUID) but I think it is fine.
An alternative could be to enforce it in `CDEProjectBrowserItem` constructor, returning nil if model and store path belongs to different simulator\apps
Guys, let me know what you think.
