### PR TITLE
Show store file in title bar

### DIFF
--- a/Core Data Editor/Core Data Editor/CDEDocument.m
+++ b/Core Data Editor/Core Data Editor/CDEDocument.m
@@ -234,7 +234,6 @@
 - (void)windowControllerDidLoadNib:(NSWindowController *)windowController {
     [super windowControllerDidLoadNib:windowController];
   
-  [self _documentWindow].titleVisibility = NSWindowTitleHidden;
     self.editorViewController.view.frame = self.containerView.bounds;
     [self.containerView addSubview:self.editorViewController.view];
     
@@ -288,6 +287,9 @@
                 [errorMessages addObject:@"• Store could not be accessed."];
                 NSLog(@"failed to access store");
             }
+			else {
+				self.fileURL = self.storeURL;
+			}
         }
         // If there aren't any error messages we can check for compatibility
         NSManagedObjectModel *model = nil;


### PR DESCRIPTION
Thought you might enjoy adding this feature. It's convenient when needing to open a Finder window to the folder where the store is

![screen shot 2015-06-17 at 12 49 07 am](https://cloud.githubusercontent.com/assets/967800/8200454/cc11a2ea-148a-11e5-8963-84e86eb59ab9.png)
![screen shot 2015-06-17 at 12 49 26 am](https://cloud.githubusercontent.com/assets/967800/8200455/cc14be1c-148a-11e5-8de7-ddfa94145e63.png)
