### PR TITLE
Use 'Latest Mac OS X SDK' instead of hardcoding the SDK version

### DIFF
--- a/Core Data Editor/Core Data Editor.xcodeproj/project.pbxproj
+++ b/Core Data Editor/Core Data Editor.xcodeproj/project.pbxproj
@@ -2586,7 +2586,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				SDKROOT = macosx10.10;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -2603,7 +2603,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
-				SDKROOT = macosx10.10;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;


### PR DESCRIPTION
This means the app will build if you're on Xcode 7.3 & El Cap