### PR TITLE
UUID type support

### DIFF
--- a/Core Data Editor/Core Data Editor.xcodeproj/project.pbxproj
+++ b/Core Data Editor/Core Data Editor.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4018D7842306011600A59D01 /* CDEUUIDAttributeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4018D7832306011600A59D01 /* CDEUUIDAttributeView.xib */; };
+		4018D7872306401100A59D01 /* CDEUUIDAttributeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4018D7862306401100A59D01 /* CDEUUIDAttributeViewController.m */; };
 		AB0181171997C805000FE094 /* NSDirectoryEnumerator+ProjectBrowser.m in Sources */ = {isa = PBXBuildFile; fileRef = AB0181161997C805000FE094 /* NSDirectoryEnumerator+ProjectBrowser.m */; };
 		AB06C0AF1854CB07002945CB /* CDEToOneRelationshipRequestDataCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = AB06C0AE1854CB07002945CB /* CDEToOneRelationshipRequestDataCoordinator.m */; };
 		AB0927511768C6EC00FC59FB /* CDEEntitiesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AB09274F1768C6EC00FC59FB /* CDEEntitiesViewController.m */; };
@@ -219,6 +221,9 @@
 
 /* Begin PBXFileReference section */
 		2E25BCB4198D645100BBA0C0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		4018D7832306011600A59D01 /* CDEUUIDAttributeView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CDEUUIDAttributeView.xib; sourceTree = "<group>"; };
+		4018D7852306401100A59D01 /* CDEUUIDAttributeViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDEUUIDAttributeViewController.h; sourceTree = "<group>"; };
+		4018D7862306401100A59D01 /* CDEUUIDAttributeViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDEUUIDAttributeViewController.m; sourceTree = "<group>"; };
 		AB0181151997C805000FE094 /* NSDirectoryEnumerator+ProjectBrowser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDirectoryEnumerator+ProjectBrowser.h"; sourceTree = "<group>"; };
 		AB0181161997C805000FE094 /* NSDirectoryEnumerator+ProjectBrowser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDirectoryEnumerator+ProjectBrowser.m"; sourceTree = "<group>"; };
 		AB06C0AD1854CB07002945CB /* CDEToOneRelationshipRequestDataCoordinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDEToOneRelationshipRequestDataCoordinator.h; sourceTree = "<group>"; };
@@ -599,6 +604,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4018D7882306401D00A59D01 /* UUID */ = {
+			isa = PBXGroup;
+			children = (
+				4018D7852306401100A59D01 /* CDEUUIDAttributeViewController.h */,
+				4018D7862306401100A59D01 /* CDEUUIDAttributeViewController.m */,
+				4018D7832306011600A59D01 /* CDEUUIDAttributeView.xib */,
+			);
+			name = UUID;
+			sourceTree = "<group>";
+		};
 		AB06C0AC1854CAD5002945CB /* To-One Relationship Request Coordinator */ = {
 			isa = PBXGroup;
 			children = (
@@ -1861,6 +1876,7 @@
 				ABEEA5BF178194B70096DE4C /* Date */,
 				ABEEA5C1178194C60096DE4C /* Number */,
 				ABEEA5C2178194CC0096DE4C /* Binary */,
+				4018D7882306401D00A59D01 /* UUID */,
 				ABC189F117809EDC00AF4F15 /* CDEAttributeViewControllerDelegate.h */,
 				ABC189F217809EDC00AF4F15 /* CDEAttributeViewController.h */,
 				ABC189F317809EDC00AF4F15 /* CDEAttributeViewController.m */,
@@ -2057,6 +2073,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = ABBEA7CD1765CB730024A9D2;
@@ -2103,6 +2120,7 @@
 				ABD5BCE317807B4F0050025B /* Relationship-ToMany.pdf in Resources */,
 				ABD5BCE417807B4F0050025B /* Relationship-ToOne.pdf in Resources */,
 				ABC18A1A17809EDC00AF4F15 /* CDEBooleanAttributeView.xib in Resources */,
+				4018D7842306011600A59D01 /* CDEUUIDAttributeView.xib in Resources */,
 				ABC18A1C17809EDC00AF4F15 /* CDEStringAttributeView.xib in Resources */,
 				ABC18A1F17809EDC00AF4F15 /* CDEDatePickerViewController.xib in Resources */,
 				ABC18A2117809EDC00AF4F15 /* CDEDateAttributeView.xib in Resources */,
@@ -2180,6 +2198,7 @@
 				AB22AC7A17664480004890AC /* NSBundle+CDEModelFinder.m in Sources */,
 				AB0927511768C6EC00FC59FB /* CDEEntitiesViewController.m in Sources */,
 				AB0927571768C81E00FC59FB /* CDEEditorViewController.m in Sources */,
+				4018D7872306401100A59D01 /* CDEUUIDAttributeViewController.m in Sources */,
 				AB0927631768E65200FC59FB /* NSURL+CDEAdditions.m in Sources */,
 				AB09276A1768F36100FC59FB /* CDEApplicationDelegate.m in Sources */,
 				AB09279B1768F73000FC59FB /* CDEManagedObjectsViewController.m in Sources */,
@@ -2421,7 +2440,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Core Data Editor/Core Data Editor-Prefix.pch";
 				INFOPLIST_FILE = "Core Data Editor/Core Data Editor-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.christian-kienle.coredataeditor5";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -2438,7 +2457,7 @@
 				GCC_PREFIX_HEADER = "Core Data Editor/Core Data Editor-Prefix.pch";
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "Core Data Editor/Core Data Editor-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "de.christian-kienle.coredataeditor5";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";

--- a/Core Data Editor/Core Data Editor/CDEAttributeViewController.m
+++ b/Core Data Editor/Core Data Editor/CDEAttributeViewController.m
@@ -5,6 +5,7 @@
 #import "CDEBooleanAttributeViewController.h"
 #import "CDEDateAttributeViewController.h"
 #import "CDEBinaryAttributeViewController.h"
+#import "CDEUUIDAttributeViewController.h"
 
 const static NSString *CDEAttributeViewControllerResultingValueObservationContext = @"CDEAttributeViewControllerResultingValueObservationContext";
 
@@ -66,6 +67,9 @@ NSString* const CDEAttributeViewControllerResultingValueKey = @"resultingValue";
     }
     if([CDEManagedObjectsTableViewAttributeHelper attributeTypeIsNumber:[attributeDescription attributeType]]) {
         return [CDENumberAttributeViewController class];
+    }
+    if([attributeDescription attributeType] == NSUUIDAttributeType) {
+        return [CDEUUIDAttributeViewController class];
     }
     return nil;
 }

--- a/Core Data Editor/Core Data Editor/CDEBinaryAttributeViewController.m
+++ b/Core Data Editor/Core Data Editor/CDEBinaryAttributeViewController.m
@@ -55,7 +55,7 @@
     NSSavePanel *panel = [NSSavePanel savePanel];
     panel.canCreateDirectories = YES;
     [panel beginSheetModalForWindow:self.view.window completionHandler:^(NSInteger result) {
-        if(result != NSFileHandlingPanelOKButton) {
+        if(result != NSModalResponseOK) {
             return;
         }
         if([[self resultingValue] isKindOfClass:[NSData class]] == NO) {
@@ -75,7 +75,7 @@
     NSOpenPanel *panel = [NSOpenPanel openPanel];
     panel.canCreateDirectories = YES;
     [panel beginSheetModalForWindow:self.view.window completionHandler:^(NSInteger result) {
-        if(result != NSFileHandlingPanelOKButton) {
+        if(result != NSModalResponseOK) {
             return;
         }
 //        if([[self resultingValue] isKindOfClass:[NSData class]] == NO) {

--- a/Core Data Editor/Core Data Editor/CDEBinaryValueTableCellView.m
+++ b/Core Data Editor/Core Data Editor/CDEBinaryValueTableCellView.m
@@ -40,7 +40,7 @@
     NSSavePanel *panel = [NSSavePanel savePanel];
     panel.canCreateDirectories = YES;
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
-        if(result != NSFileHandlingPanelOKButton) {
+        if(result != NSModalResponseOK) {
             return;
         }
         if([self.objectValue isKindOfClass:[NSData class]] == NO) {

--- a/Core Data Editor/Core Data Editor/CDECSVImportWindowController.m
+++ b/Core Data Editor/Core Data Editor/CDECSVImportWindowController.m
@@ -151,7 +151,7 @@ NSString *const CDECSVImportWindowControllerMappingIndexOfSelectedColumn = @"ind
     panel.allowedFileTypes = @[@"csv"];
     panel.accessoryView = self.delimiterViewController.view;
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
-        BOOL userChoseOKButton = (NSFileHandlingPanelOKButton == result);
+        BOOL userChoseOKButton = (NSModalResponseOK == result);
         if(userChoseOKButton == NO) {
             return;
         }

--- a/Core Data Editor/Core Data Editor/CDEDropStoreViewController.m
+++ b/Core Data Editor/Core Data Editor/CDEDropStoreViewController.m
@@ -74,7 +74,7 @@
 - (IBAction)createNewStore:(id)sender {
     NSSavePanel *panel = [NSSavePanel savePanel];
     [panel beginSheetModalForWindow:self.view.window completionHandler:^(NSInteger result) {
-        if(result != NSFileHandlingPanelOKButton) {
+        if(result != NSModalResponseOK) {
             return;
         }
         NSURL *URL = [panel URL];

--- a/Core Data Editor/Core Data Editor/CDEManagedObjectsTableViewAttributeHelper.m
+++ b/Core Data Editor/Core Data Editor/CDEManagedObjectsTableViewAttributeHelper.m
@@ -29,7 +29,7 @@
 }
 
 + (BOOL)attributeTypeIsDisplayable:(NSAttributeType)attributeType {
-    return (attributeType == NSInteger16AttributeType || attributeType == NSInteger32AttributeType || attributeType == NSInteger64AttributeType || attributeType == NSDecimalAttributeType || attributeType == NSDoubleAttributeType || attributeType == NSFloatAttributeType || attributeType == NSBooleanAttributeType || attributeType == NSStringAttributeType || attributeType == NSBooleanAttributeType || attributeType == NSDateAttributeType || attributeType == NSBinaryDataAttributeType || attributeType == NSTransformableAttributeType);
+    return (attributeType == NSInteger16AttributeType || attributeType == NSInteger32AttributeType || attributeType == NSInteger64AttributeType || attributeType == NSDecimalAttributeType || attributeType == NSDoubleAttributeType || attributeType == NSFloatAttributeType || attributeType == NSBooleanAttributeType || attributeType == NSStringAttributeType || attributeType == NSUUIDAttributeType || attributeType == NSBooleanAttributeType || attributeType == NSDateAttributeType || attributeType == NSBinaryDataAttributeType || attributeType == NSTransformableAttributeType);
 }
 
 + (NSTableColumn *)tableColumnWithAttributeDescription:(NSAttributeDescription *)attributeDescription arrayController:(NSArrayController *)arrayController {

--- a/Core Data Editor/Core Data Editor/CDERequestDataCoordinator.m
+++ b/Core Data Editor/Core Data Editor/CDERequestDataCoordinator.m
@@ -351,7 +351,11 @@
     NSManagedObject *object = [self managedObjectAtIndex:row];
     NSTableColumn *tableColumn = [self.tableView tableColumns][column];
 
-    [object setValue:[[notification object] objectValue] forKey:tableColumn.identifier];
+    id value = [[notification object] objectValue];
+    if ([self attributeTypeForTableColumn:tableColumn] == NSUUIDAttributeType) {
+        value = [[NSUUID alloc] initWithUUIDString:value];
+    }
+    [object setValue:value forKey:tableColumn.identifier];
 }
 
 - (void)binaryValueTextField:(NSTextField *)textField didChangeBinaryValue:(NSData *)binaryValue {
@@ -421,7 +425,11 @@
 //    self.datePicker.representedObject = representedObject;
 
     [self.textEditorController showRelativeToRect:[sender bounds] ofView:sender preferredEdge:NSMinYEdge stringValue:stringValue completionHandler:^(NSString *editedStringValue) {
-        [object setValue:editedStringValue forKey:property.name];
+        id value = editedStringValue;
+        if ([self attributeTypeForTableColumn:tableColumn] == NSUUIDAttributeType) {
+            value = [[NSUUID alloc] initWithUUIDString:value];
+        }
+        [object setValue:value forKey:property.name];
         NSUInteger rowIndex = [self indexOfManagedObject:object];
         NSIndexSet *columIndexes = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.tableColumns.count)];
         [self.tableView reloadDataForRowIndexes:[NSIndexSet indexSetWithIndex:rowIndex] columnIndexes:columIndexes];
@@ -511,6 +519,9 @@
 + (id)transformedValueFromString:(NSString *)inputString attributeType:(NSAttributeType)attributeType {
     if(attributeType == NSStringAttributeType) {
         return inputString;
+    }
+    if(attributeType == NSUUIDAttributeType) {
+        return [[NSUUID alloc] initWithUUIDString:inputString];
     }
     if([NSAttributeDescription attributeTypeHasIntegerCharacteristics_cde:attributeType]) {
         NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];

--- a/Core Data Editor/Core Data Editor/CDESetupWindowController.m
+++ b/Core Data Editor/Core Data Editor/CDESetupWindowController.m
@@ -40,7 +40,7 @@
   [panel setCanChooseFiles:NO];
   [panel setShowsHiddenFiles:YES];
   [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
-    if(result == NSFileHandlingPanelOKButton) {
+      if(result == NSModalResponseOK) {
       NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
       defaults.simulatorDirectory_cde = panel.URL;
       self.simulatorPathPopupButton.URL = defaults.simulatorDirectory_cde;
@@ -53,7 +53,7 @@
   [panel setCanChooseDirectories:YES];
   [panel setCanChooseFiles:NO];
   [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
-    if(result == NSFileHandlingPanelOKButton) {
+      if(result == NSModalResponseOK) {
       NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
       defaults.buildProductsDirectory_cde = panel.URL;
       self.derivedDataPathPopupButton.URL = defaults.buildProductsDirectory_cde;

--- a/Core Data Editor/Core Data Editor/CDEUUIDAttributeView.xib
+++ b/Core Data Editor/Core Data Editor/CDEUUIDAttributeView.xib
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="CDEStringAttributeViewController">
+            <connections>
+                <outlet property="attributeNameTextField" destination="33" id="38"/>
+                <outlet property="attributeNameView" destination="32" id="37"/>
+                <outlet property="valueView" destination="8" id="26"/>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application"/>
+        <customView id="1" userLabel="Value" customClass="CDEAttributeView">
+            <rect key="frame" x="0.0" y="0.0" width="273" height="27"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" id="8">
+                    <rect key="frame" x="0.0" y="4" width="273" height="19"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="9">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="-2" name="value" keyPath="resultingValue" id="11">
+                            <dictionary key="options">
+                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                            </dictionary>
+                        </binding>
+                        <outlet property="delegate" destination="-2" id="24"/>
+                    </connections>
+                </textField>
+            </subviews>
+        </customView>
+        <customView id="32" userLabel="Name">
+            <rect key="frame" x="0.0" y="0.0" width="273" height="57"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <textField verticalHuggingPriority="750" id="33">
+                    <rect key="frame" x="17" y="20" width="254" height="14"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="right" title="Label" id="34" customClass="CDEShadowTextFieldCell">
+                        <font key="font" metaFont="smallSystemBold"/>
+                        <color key="textColor" red="0.3803921938" green="0.3803921938" blue="0.3803921938" alpha="1" colorSpace="deviceRGB"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="-2" name="displayPatternValue1" keyPath="attributeDescription.nameForDisplay_cde" id="41">
+                            <dictionary key="options">
+                                <string key="NSDisplayPattern">%{value1}@</string>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
+            </subviews>
+        </customView>
+    </objects>
+</document>

--- a/Core Data Editor/Core Data Editor/CDEUUIDAttributeViewController.h
+++ b/Core Data Editor/Core Data Editor/CDEUUIDAttributeViewController.h
@@ -1,0 +1,17 @@
+//
+//  CDEUUIDAttributeViewController.h
+//  Core Data Editor
+//
+//  Created by Steve Madsen on 8/15/19.
+//  Copyright © 2019 Christian Kienle. All rights reserved.
+//
+
+#import "CDEAttributeViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CDEUUIDAttributeViewController : CDEAttributeViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Core Data Editor/Core Data Editor/CDEUUIDAttributeViewController.m
+++ b/Core Data Editor/Core Data Editor/CDEUUIDAttributeViewController.m
@@ -1,0 +1,35 @@
+//
+//  CDEUUIDAttributeViewController.m
+//  Core Data Editor
+//
+//  Created by Steve Madsen on 8/15/19.
+//  Copyright © 2019 Christian Kienle. All rights reserved.
+//
+
+#import "CDEUUIDAttributeViewController.h"
+
+@implementation CDEUUIDAttributeViewController
+
+#pragma mark CMKViewController
+- (NSString *)nibName {
+    return @"CDEUUIDAttributeView";
+}
+
+- (BOOL)control:(NSControl *)control textShouldEndEditing:(NSText *)fieldEditor {
+    if ([[NSUUID alloc] initWithUUIDString:[fieldEditor string]] != nil) {
+        return YES;
+    }
+    
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.informativeText = [NSString stringWithFormat:@"Input '%@' is not a UUID", [fieldEditor string]];
+    alert.messageText = @"Validation Error";
+    [alert runModal];
+
+    return NO;
+}
+
+- (void) setResultingValue:(id)newValue {
+    [super setResultingValue:[[NSUUID alloc] initWithUUIDString:newValue]];
+}
+
+@end

--- a/Core Data Editor/Core Data Editor/NSAttributeDescription+CDEAdditions.m
+++ b/Core Data Editor/Core Data Editor/NSAttributeDescription+CDEAdditions.m
@@ -8,7 +8,8 @@
 
 #pragma mark - Working with Attribute Types
 BOOL CDEIsStringAttributeType(NSAttributeType type) {
-    return (type == NSStringAttributeType);
+    return (type == NSStringAttributeType ||
+            type == NSUUIDAttributeType);
 }
 
 BOOL CDEIsFloatingPointAttributeType(NSAttributeType type) {
@@ -40,6 +41,7 @@ BOOL CDEIsIntegerAttributeType(NSAttributeType type) {
             result = [CDEFloatingPointValueTableCellView class];
             break;
         case NSStringAttributeType:
+        case NSUUIDAttributeType:
             result = [CDEStringValueTableCellView class];
             break;
         case NSBooleanAttributeType:

--- a/Core Data Editor/Core Data Editor/PreferencesIntegrationVC.m
+++ b/Core Data Editor/Core Data Editor/PreferencesIntegrationVC.m
@@ -50,7 +50,7 @@
     [panel setCanChooseDirectories:YES];
     [panel setCanChooseFiles:NO];
     [panel beginSheetModalForWindow:self.view.window completionHandler:^(NSInteger result) {
-        if(result == NSFileHandlingPanelOKButton) {
+        if(result == NSModalResponseOK) {
             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
             defaults.simulatorDirectory_cde = panel.URL;
             self.simulatorDirectoryPopUpButton.URL = defaults.simulatorDirectory_cde;
@@ -63,7 +63,7 @@
     [panel setCanChooseDirectories:YES];
     [panel setCanChooseFiles:NO];
     [panel beginSheetModalForWindow:self.view.window completionHandler:^(NSInteger result) {
-        if(result == NSFileHandlingPanelOKButton) {
+        if(result == NSModalResponseOK) {
             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
             defaults.buildProductsDirectory_cde = panel.URL;
             self.buildDirectoryPopUpButton.URL = defaults.buildProductsDirectory_cde;


### PR DESCRIPTION
This PR is a first attempt at adding support for UUID attributes (issue #56).

* UUID types show up and are editable in the table view for an entity type.
* UUID types show up and are editable in the managed object view (what you see when you click on a to-one association for a record selected in the upper table view).

Note that I bumped the deployment target to macOS 10.13 since that's when the NSUUID type is first available.